### PR TITLE
Hotfix for APPIUM_APP_SIZE_DISABLE env property parsing

### DIFF
--- a/files/mcloud/node_modules/@appium/base-driver/build/lib/basedriver/helpers.js
+++ b/files/mcloud/node_modules/@appium/base-driver/build/lib/basedriver/helpers.js
@@ -183,7 +183,7 @@ async function configureApp(app, options = /** @type {import('@appium/types').Co
                 const waitingTime = 1000;
                 const maxAttemptsCount = Number(process.env.APPIUM_APP_WAITING_TIMEOUT);
                 const maxLockFileLifetime = Number(process.env.APPIUM_MAX_LOCK_FILE_LIFETIME);
-                const appSizeCheckDisabled = Boolean(process.env.APPIUM_APP_SIZE_DISABLE?.toLowerCase);
+                const appSizeCheckDisabled = Boolean(process.env.APPIUM_APP_SIZE_DISABLE?.toLowerCase?.() === 'true');
                 let appFetchRetries = Number(process.env.APPIUM_APP_FETCH_RETRIES);
                 if (localAppsFolder != undefined) {
                     localFile = await (0, mcloud_utils_1.getLocalFileForAppUrl)(newApp);

--- a/files/mcloud/node_modules/appium-2_2_2.diff
+++ b/files/mcloud/node_modules/appium-2_2_2.diff
@@ -135,7 +135,7 @@ index 5f89176ba..48a431c0d 100644
 +        const waitingTime = 1000;
 +        const maxAttemptsCount = Number(process.env.APPIUM_APP_WAITING_TIMEOUT);
 +        const maxLockFileLifetime = Number(process.env.APPIUM_MAX_LOCK_FILE_LIFETIME);
-+        const appSizeCheckDisabled = Boolean(process.env.APPIUM_APP_SIZE_DISABLE?.toLowerCase);
++        const appSizeCheckDisabled = Boolean(process.env.APPIUM_APP_SIZE_DISABLE?.toLowerCase?.() === 'true');
 +        let appFetchRetries = Number(process.env.APPIUM_APP_FETCH_RETRIES);
 +        
 +        if(localAppsFolder != undefined) {


### PR DESCRIPTION
I found out that value for APPIUM_APP_SIZE_DISABLE environment property still was not parsed successfully.
When the value was set to 'False' it still was parsed as 'true'.
The problem was in how string was converted to a boolean.
Now it should be finally fixed. Tested it in local environment.